### PR TITLE
Fix event loop retrieval for Python 3.10+

### DIFF
--- a/utils/gemini_wrapper.py
+++ b/utils/gemini_wrapper.py
@@ -7,7 +7,7 @@ genai.configure(api_key=GEMINI_API_KEY)
 model = genai.GenerativeModel("gemma-3-27b-it")
 
 async def ask_gemini_question(prompt: str) -> str:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     try:
         response = await asyncio.wait_for(
             loop.run_in_executor(None, model.generate_content, prompt),


### PR DESCRIPTION
## Summary
- update gemini wrapper to use `asyncio.get_running_loop`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbad33334832496f5bf76e29b7166